### PR TITLE
Fix the splide issue. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@heroicons/react": "^2.0.18",
         "@reduxjs/toolkit": "^1.9.5",
+        "@splidejs/react-splide": "^0.7.12",
         "lodash": "^4.17.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -970,6 +971,19 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@splidejs/react-splide": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@splidejs/react-splide/-/react-splide-0.7.12.tgz",
+      "integrity": "sha512-UfXH+j47jsMc4x5HA/aOwuuHPqn6y9+ZTNYPWDRD8iLKvIVMZlzq2unjUEvyDAU+TTVPZOXkG2Ojeoz0P4AkZw==",
+      "dependencies": {
+        "@splidejs/splide": "^4.1.3"
+      }
+    },
+    "node_modules/@splidejs/splide": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.4.tgz",
+      "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA=="
     },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@heroicons/react": "^2.0.18",
     "@reduxjs/toolkit": "^1.9.5",
+    "@splidejs/react-splide": "^0.7.12",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/Stories.jsx
+++ b/src/components/Stories.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Splide, SplideSlide } from "@splidejs/react-splide";
-import "@splidejs/splide/css";
+import "@splidejs/splide/dist/css";
 import { HashtagIcon, HeartIcon } from "@heroicons/react/24/solid";
 import { ClockIcon } from "@heroicons/react/24/outline";
 import Title from "./utils/Title";

--- a/src/components/Stories.jsx
+++ b/src/components/Stories.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Splide, SplideSlide } from "@splidejs/react-splide";
-import "@splidejs/splide/dist/css";
+import { Splide, SplideSlide } from "/node_modules/@splidejs/react-splide";
+import "@splidejs/splide/css";
 import { HashtagIcon, HeartIcon } from "@heroicons/react/24/solid";
 import { ClockIcon } from "@heroicons/react/24/outline";
 import Title from "./utils/Title";


### PR DESCRIPTION
The reason behind the splide issues was.

"The error typically happens when Module Specifiers exist in your client-side import statements. The browser does not understand Module Specifiers by default."

we need to import manually 

import { Splide, SplideSlide } from "/node_modules/@splidejs/react-splide";

Below is the deployed link that I have tested. 

https://nike-store-react-rosy.vercel.app/

